### PR TITLE
Add tokio async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,9 @@ edition = "2021"
 [dependencies]
 chrono = "0.4"
 lazy_static = "1.4"
+
+tokio = { version = "1.40.0", optional = true, features = [ "fs", "io-std", "sync", "io-util" ] }
+
+[features]
+async-tokio = [ "tokio" ]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4"
-lazy_static = "1.4"
 
 tokio = { version = "1.40.0", optional = true, features = [ "fs", "io-std", "sync", "io-util" ] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,62 @@
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::sync::Mutex;
+use std::sync::OnceLock;
 use chrono::Local;
-use lazy_static::lazy_static;
 
-lazy_static! {
-    static ref LOG_FILE: Mutex<std::fs::File> = Mutex::new(
-        OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("server.log")
-            .expect("Failed to open log file")
-    );
-}
+// import async specific stuff, if enabled
+#[cfg(feature = "async-tokio")]
+use tokio::fs::File;
+#[cfg(feature = "async-tokio")]
+use tokio::sync::Mutex;
+#[cfg(feature = "async-tokio")]
+use tokio::io::AsyncWriteExt;
+#[cfg(feature = "async-tokio")]
+use tokio::fs::OpenOptions;
 
+// and then blocking specific stuff, if enabled
+#[cfg(not(feature = "async-tokio"))]
+use std::fs::File;
+#[cfg(not(feature = "async-tokio"))]
+use std::sync::Mutex;
+#[cfg(not(feature = "async-tokio"))]
+use std::io::Write;
+#[cfg(not(feature = "async-tokio"))]
+use std::fs::OpenOptions;
+
+static LOG_FILE: OnceLock<Mutex<File>> = OnceLock::new();
+
+#[cfg(not(feature = "async-tokio"))]
 pub fn log_message(message: &str) {
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
     let log_message = format!("[{}] {}\n", timestamp, message);
-    
+
     print!("{}", log_message);  // Print to console
-    
-    if let Ok(mut file) = LOG_FILE.lock() {
+
+    if let Ok(mut file) = LOG_FILE.get().unwrap().lock() {
         let _ = file.write_all(log_message.as_bytes());
     }
 }
 
+#[cfg(feature = "async-tokio")]
+pub async fn log_message(message: &str) {
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let log_message = format!("[{}] {}\n", timestamp, message);
+
+    print!("{}", log_message);  // Print to console
+
+    if let Some(lock) = LOG_FILE.get() {
+        let mut file = lock.lock().await;
+        let _ = file.write_all(log_message.as_bytes()).await;
+    }
+}
+
+#[cfg(feature = "async-tokio")]
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {{
+        let message = format!($($arg)*);
+        $crate::log_message(&message).await;
+    }};
+}
+#[cfg(not(feature = "async-tokio"))]
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {{
@@ -33,6 +65,34 @@ macro_rules! println {
     }};
 }
 
+#[cfg(not(feature = "async-tokio"))]
 pub fn init() {
+    let log_file: Mutex<File> = Mutex::new(
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("server.log")
+            .expect("Failed to open log file")
+            .into()
+    );
+    LOG_FILE.set(log_file).expect("Failed to initialize LOG_FILE");
+
     println!("Logging system initialized");
 }
+
+#[cfg(feature = "async-tokio")]
+pub async fn init() {
+    let log_file: Mutex<File> = Mutex::new(
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("server.log")
+            .await
+            .expect("Failed to open log file")
+            .into()
+    );
+    LOG_FILE.set(log_file).expect("Failed to initialize LOG_FILE");
+
+    println!("Logging system initialized");
+}
+


### PR DESCRIPTION
this pull request adds async/await support with tokio to ez_logging. this is optional and can be enabled by compiling `ez_logging` with the feature `async-tokio`. `tokio` will not be compiled along the binary if the feature is not enabled

# why??

`ez_logging` currently only uses blocking io, which can drastically slow things down, especially in places with a lot of `println!()`.

when working with async/await, you usually don't want to call blocking functions, as tokio implements a form of cooperative scheduling (where you yield at `.await`). if you do so anyway, you reduce the amount of threads the scheduler can schedule on.

## code changes

in order to achieve this goal, there were quite a bit of refactorings:

- removed `lazy_static` as a dependency in favor of  `std::sync::OnceLock`
  ... because i can't figure out how to lazily initialize something with await
- created multiple (repeated) functions because functions that are async need to be marked as such
